### PR TITLE
FIX Use day of year instead of day of week

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -11,8 +11,8 @@ runs:
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
-        # repository that has a twice-weekly schedule run on consequtive days - use day of week
-        date_part=$(date +%u)
+        # repository that has a twice-weekly schedule run on consecutive days - use day of year
+        date_part=$(date +%-j)
         type=""
         if [[ $GITHUB_REPOSITORY == "silverstripe/installer" ]] || \
             [[ $GITHUB_REPOSITORY == "silverstripe/recipe-kitchen-sink" ]]


### PR DESCRIPTION
Issue https://github.com/silverstripe/recipe-kitchen-sink/issues/44

Instead of running on 5 and 4.13 branches, repos with crons detp to run on Sunday + Monday will always run the 5 branch and never the 4.13 branch/ We use mod 2 to detect if the day of week is odd or even to work out which branch to run on. Sunday + Monday bother return the same value

This PR changes this to day of year instead