### PR TITLE
FIX Skip running CI on cycle if only a single major

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -61,8 +61,8 @@ runs:
             major_branch=$(echo "$major_branches" | head -1)
         elif [[ $major_type == "previous" ]]; then
             if (( $major_branches_count < 2 )); then
-                echo "Only one major branch found"
-                exit 1
+                echo "Only one major branch found, not running CI on this cycle - will run on next cycle"
+                exit 0
             fi
             major_branch=$(echo "$major_branches" | head -2 | tail -1)
         fi


### PR DESCRIPTION
Issue https://github.com/silverstripe/module-standardiser/issues/37

Some standardized modules are new and only have a single major.  In these instance just skip running CI instead of erroring when nothing is wrong.

For example: https://github.com/silverstripe/silverstripe-standards/actions
