### PR TITLE
FIX Handle blank inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,11 @@
 
 Used to trigger CI workflows on a schedule. This workflow allows multiple branches to have CI workflows run on a schedule, rather than just the default branch.
 
-For modules that are to be scheduled once per week, the cron must be run two times per week on consecutive days. This is done because there is logic in action.yml to run one job for the latest patch branch on the previous major on "even" days of the week and the next minor branch for the current major on "odd" days of the week.
+For modules that are to be scheduled once per week, the cron must be run three times per week on consecutive days. This is done because there is logic in action.yml to run one jobs on consecutive days for:
 
-For builds that are to be scheduled once per day, specifically `silverstripe/installer` and `silverstripe/recipe-kitchen-sink`, the cron must be run two times per day on consecutive hours, because for these modules branches on the previous major version are run on "even" hours and branches on the current major version are run on "odd" hours.
-
-### Disabling branches on previous major version
-
-If the previous major version reaches the point in its life cycle where it is only receiving security fixes and no longer needs the cron job to run, it can be disabled by setting `RUN_BRANCHES_ON_PREVIOUS_MAJOR: "false"` in the `Check if should dispatch workflow` step in `actions.yml`.
-
-Remember to set this to `true` when a new major version is released.
+- Current major, next-minor e.g. "6"
+- Current major, next-patch e.g. "6.0"
+- Previous major, next-patch e.g. "5.4"
 
 ### Usage
 
@@ -19,9 +15,30 @@ Remember to set this to `true` when a new major version is released.
 name: Dispatch CI
 
 on:
-  # Every Tuesday,Wednesday at 1:00pm UTC
+  # Every Tuesday,Wednesday,Thursday at 1:00pm UTC
   schedule:
-    - cron: '0 13 * * 2,3'
+    - cron: '0 13 * * 2,3,4'
+  workflow_dispatch:
+    inputs:
+      major_type:
+        description: 'Major branch type'
+        required: true
+        type: choice
+        options:
+          - 'dynamic'
+          - 'current'
+          - 'next'
+          - 'previous'
+        default: 'dynamic'
+      minor_type:
+        description: 'Minor branch type'
+        required: true
+        type: choice
+        options:
+          - 'dynamic'
+          - 'next-minor'
+          - 'next-patch'
+        default: 'dynamic'
 
 permissions: {}
 
@@ -37,14 +54,17 @@ jobs:
     steps:
       - name: Dispatch CI
         uses: silverstripe/gha-dispatch-ci@v1
+        with:
+          major_type: ${{ inputs.major_type }}
+          minor_type: ${{ inputs.minor_type }}
 ```
 
 ### Inputs:
 
 #### Major Type
-The major version type to target, can be `dynamic`, `current`, `next`, `previous`. Default is `dynamic`.
+The major version type to target, can be `(blank)`, `dynamic`, `current`, `next`, `previous`. Default is `dynamic`.
 `major_type: current`
 
 #### Minor Type
-The minor version type to target, can be `dynamic`, `next-minor`, `next-patch`. Default is `dynamic`.
+The minor version type to target, can be `(blank)`, `dynamic`, `next-minor`, `next-patch`. Default is `dynamic`.
 `minor_type: next-minor`

--- a/action.yml
+++ b/action.yml
@@ -20,7 +20,8 @@ runs:
         INPUTS_MAJOR_TYPE: ${{ inputs.major_type }}
         INPUTS_MINOR_TYPE: ${{ inputs.minor_type }}
       run: |
-        if [[ $INPUTS_MAJOR_TYPE != "dynamic" ]] && \
+        if [[ $INPUTS_MAJOR_TYPE != "" ]] && \
+          [[ $INPUTS_MAJOR_TYPE != "dynamic" ]] && \
           [[ $INPUTS_MAJOR_TYPE != "current" ]] && \
           [[ $INPUTS_MAJOR_TYPE != "next" ]] && \
           [[ $INPUTS_MAJOR_TYPE != "previous" ]]
@@ -28,7 +29,8 @@ runs:
           echo "Invalid input major_type"
           exit 1
         fi
-        if [[ $INPUTS_MINOR_TYPE != "dynamic" ]] && \
+        if [[ $INPUTS_MINOR_TYPE != "" ]] && \
+          [[ $INPUTS_MINOR_TYPE != "dynamic" ]] && \
           [[ $INPUTS_MINOR_TYPE != "next-minor" ]] && \
           [[ $INPUTS_MINOR_TYPE != "next-patch" ]]
         then
@@ -44,6 +46,14 @@ runs:
         INPUTS_MAJOR_TYPE: ${{ inputs.major_type }}
         GITHUB_REPOSITORY: ${{ github.repository }}
       run: |
+        # Inputs will normally be blank as this action is called in a modules dispatch.yml with inputs arguments
+        # though without values when started on a schedule
+        if [[ $INPUTS_MAJOR_TYPE == "" ]]; then
+          INPUTS_MAJOR_TYPE='dynamic'
+        fi
+        if [[ $INPUTS_MINOR_TYPE == "" ]]; then
+          INPUTS_MINOR_TYPE='dynamic'
+        fi
         # Repositories run on a three times weekly schedule run on consecutive days
         # Get the current day of year (e.g. Feb 15 is 46) which will be used for a mod calc below
         DATE_PART=$(date +%-j)


### PR DESCRIPTION
Issue https://github.com/silverstripe/gha-dispatch-ci/issues/28

Issue happens on all repos, not just framework

Issue was that dispatch-ci.yml passes input args to the action, though only defines them on workflow_dispatch, not schedule

This fix handles blank inputs

Also updated the readme which was out of date

I've tested here - https://github.com/emteknetnz/silverstripe-campaign-admin/actions/runs/17117243905/job/48550634052 - note that it doesn't actually trigger ci.yml due to that fork not being in the supported module list (because it has a non-silverstripe account name) - however you can see in the job output that it's correctly finding a major + minor branch
